### PR TITLE
Commit i7-8550U notice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # DELL 5570 hackintosh-opencore BigSur 11.0.1
+
+**Does not work (completely) on the i7-8550U variant! If you want to Hackintosh your Kaby Lake Refresh version, go <a href="https://github.com/Doregon/Inspiron-5570-KBR-Hackintosh">here</a> to find a completely working copy!
+
 Bootloader Opencore 0.6.3
 
 Kext : all updated


### PR DESCRIPTION
This doesn't work exactly the way it could on the i7-8550U variant. I've made my own configuration from your hard work and have put a notice that the people should use my variant if they have the Kaby Lake Refresh edition of the 5570.